### PR TITLE
Rename to Omniauth::Drip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Omniauth::Getdrip
+# Omniauth::Drip
 
-This Gem contains the Getdrip strategy for OmniAuth.
+This Gem contains the [Drip](https://www.getdrip.com) strategy for OmniAuth.
 
 ## Before You Begin
 
@@ -13,20 +13,20 @@ You should have already installed OmniAuth into your app; if not, read the [Omni
 First start by adding this gem to your Gemfile:
 
 ```ruby
-gem 'omniauth-getdrip'
+gem 'omniauth-drip'
 ```
 
 If you need to use the latest HEAD version, you can do so with:
 
 ```ruby
-gem 'omniauth-getdrip', github: 'waitlisted/omniauth-getdrip'
+gem 'omniauth-drip', github: 'waitlisted/omniauth-drip'
 ```
 
 Next, tell OmniAuth about this provider. For a Rails app, your `config/initializers/omniauth.rb` file should look like this:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :getdrip, "API_KEY", "API_SECRET"
+  provider :drip, "API_KEY", "API_SECRET"
 end
 ```
 
@@ -39,4 +39,3 @@ end
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
-

--- a/lib/omniauth-drip.rb
+++ b/lib/omniauth-drip.rb
@@ -1,0 +1,2 @@
+require 'omniauth-drip/version'
+require 'omniauth/strategies/drip'

--- a/lib/omniauth-drip/version.rb
+++ b/lib/omniauth-drip/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
-  module Getdrip
+  module Drip
     VERSION = "2.0.2"
   end
 end

--- a/lib/omniauth-getdrip.rb
+++ b/lib/omniauth-getdrip.rb
@@ -1,2 +1,0 @@
-require 'omniauth-getdrip/version'
-require 'omniauth/strategies/getdrip'

--- a/lib/omniauth/strategies/drip.rb
+++ b/lib/omniauth/strategies/drip.rb
@@ -2,9 +2,9 @@ require 'omniauth/strategies/oauth2'
 
 module OmniAuth
   module Strategies
-    class Getdrip < OmniAuth::Strategies::OAuth2
+    class Drip < OmniAuth::Strategies::OAuth2
 
-      option :name, "getdrip"
+      option :name, "drip"
 
       option :access_token_options, {
         :header_format => 'Bearer %s',

--- a/omniauth-drip.gemspec
+++ b/omniauth-drip.gemspec
@@ -1,14 +1,14 @@
 # coding: utf-8
-require File.expand_path('../lib/omniauth-getdrip/version', __FILE__)
+require File.expand_path('../lib/omniauth-drip/version', __FILE__)
 
 Gem::Specification.new do |spec|
-  spec.name          = "omniauth-getdrip"
-  spec.version       = Omniauth::Getdrip::VERSION
+  spec.name          = "omniauth-drip"
+  spec.version       = Omniauth::Drip::VERSION
   spec.authors       = ["j-mcnally"]
   spec.email         = ["justin@waitlisted.co"]
   spec.description   = %q{OmniAuth strategy for Getdrip}
   spec.summary       = %q{OmniAuth strategy for Getdrip.com}
-  spec.homepage      = "https://github.com/waitlisted/omniauth-getdrip.git"
+  spec.homepage      = "https://github.com/waitlisted/omniauth-drip.git"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 0"
 end


### PR DESCRIPTION
Thanks for building this, @j-mcnally! :star2: We are planning to link to this gem from our official API docs soon.

CTO of Drip here. For the sake of naming consistency, I'd like to propose renaming this to `Omniauth::Drip` (our domain is getdrip.com, but the product name is Drip). I think I covered all the bases in this PR.
